### PR TITLE
Add Algolia site verification meta tag to homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
+import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -32,6 +33,9 @@ export default function Home() {
     const { siteConfig } = useDocusaurusContext();
     return (
         <Layout title={`${siteConfig.title}`} description="WildDuck is a scalable no-SPOF IMAP/POP3 mail server">
+            <Head>
+                <meta name="algolia-site-verification" content="32E615925C237CCD" />
+            </Head>
             <HomepageHeader />
             <main>
                 <HomepageFeatures />


### PR DESCRIPTION
## Summary
- Adds the `algolia-site-verification` meta tag (`32E615925C237CCD`) to the homepage `<head>` so Algolia can verify ownership of docs.wildduck.email.

## Test plan
- [ ] `npm run build` succeeds
- [ ] After deploy, view-source on https://docs.wildduck.email/ shows the meta tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)